### PR TITLE
But fix in nanoseq_results_plotter.R

### DIFF
--- a/R/nanoseq_results_plotter.R
+++ b/R/nanoseq_results_plotter.R
@@ -374,6 +374,7 @@ pyrvsmask_unmasked = pyrvsmask[which(pyrvsmask$ismasked == 0),]
 tri_bg = pyrvsmask_unmasked$count
 names(tri_bg) = pyrvsmask_unmasked$pyrcontext
 tri_bg[setdiff(names(genome_counts), names(tri_bg))] = 0
+tri_bg = tri_bg[names(genome_counts)]
 
 if (n_variants > 0) {
 

--- a/R/nanoseq_results_plotter.R
+++ b/R/nanoseq_results_plotter.R
@@ -457,6 +457,7 @@ pyrvsmask_unmasked = pyrvsmask[which(pyrvsmask$ismasked == 0),]
 tri_bg = pyrvsmask_unmasked$count
 names(tri_bg) = pyrvsmask_unmasked$pyrcontext
 tri_bg[setdiff(names(genome_counts), names(tri_bg))] = 0
+tri_bg = tri_bg[names(genome_counts)]
 
 colours = rep(c("deepskyblue", "black", "firebrick2", "gray", "darkolivegreen3", "rosybrown2"), each = 16)
 #colours        = rep(c("dodgerblue","black","red","grey70","olivedrab3","plum2"),each=16)


### PR DESCRIPTION
Bug fix - noticed when running the pipeline on mouse and providing a trinucleotide frequencies file as argument