### PR TITLE
Use integer type for record position

### DIFF
--- a/R/snv_merge_and_vaf_calc.R
+++ b/R/snv_merge_and_vaf_calc.R
@@ -99,7 +99,7 @@ if (indel_vcf != '-') {
 }
 num_indels = as.integer(num_indels)
 
-col_t = c("character","numeric","character","character","character","character","character")
+col_t = c("character","integer","character","character","character","character","character")
 if (num_snvs == 0) {
   cat("No SNVs, skipping snv analysis...\n")
 } else {
@@ -113,7 +113,7 @@ if (num_snvs == 0) {
   colnames(snvs)[1:8] = c("chr", "pos", "kk", "ref", "mut", "qual", "filter", "info")
 }
 
-col_t2 = c("character","numeric","character","character","character","numeric","character","character","character","character")
+col_t2 = c("character","integer","character","character","character","numeric","character","character","character","character")
 if (num_indels == 0) {
   cat("No Indels, skipping indel analysis...\n")
 } else {


### PR DESCRIPTION
Use integer type for record position. At high positions 'numeric' could get converted to str format, which broke some VCF parsing